### PR TITLE
[WIP] ✨ Entropy Collector

### DIFF
--- a/.gas-snapshot
+++ b/.gas-snapshot
@@ -1,147 +1,26 @@
-No files changed, compilation skipped
-
-Running 7 tests for test/OptionSettlementEngine.integration.t.sol:OptionSettlementIntegrationTest
-[32m[PASS][0m test_integrationAddOptionsToExistingClaim() (gas: 393763)
-[32m[PASS][0m test_integrationDustHandling() (gas: 891608)
-[32m[PASS][0m test_integrationFairAssignment() (gas: 594889)
-[32m[PASS][0m test_integrationRandomAssignment() (gas: 890655)
-[32m[PASS][0m test_integrationSweepFeesWhenFeesAccruedForExercise() (gas: 1406468)
-[32m[PASS][0m test_integrationSweepFeesWhenFeesAccruedForWrite() (gas: 1330224)
-[32m[PASS][0m test_integrationWriteExerciseAddBuckets() (gas: 1106704)
-Test result: [32mok[0m. 7 passed; 0 failed; finished in 7.99ms
-
-Running 68 tests for test/OptionSettlementEngine.unit.t.sol:OptionSettlementUnitTest
-[32m[PASS][0m testRevert_acceptFeeTo_whenNotPendingFeeTo() (gas: 35301)
-[32m[PASS][0m testRevert_claim_whenClaimDoesNotExist() (gas: 13769)
-[32m[PASS][0m testRevert_construction_whenFeeToIsZeroAddress() (gas: 2055503)
-[32m[PASS][0m testRevert_construction_whenTokenURIGeneratorIsZeroAddress() (gas: 39941)
-[32m[PASS][0m testRevert_exercise_whenCallerHasNotGrantedSufficientApprovalToEngine() (gas: 578957)
-[32m[PASS][0m testRevert_exercise_whenCallerHoldsInsufficientExerciseAsset() (gas: 577114)
-[32m[PASS][0m testRevert_exercise_whenCallerHoldsInsufficientOptions() (gas: 262498)
-[32m[PASS][0m testRevert_exercise_whenExerciseTooEarly() (gas: 265916)
-[32m[PASS][0m testRevert_exercise_whenExpiredOption() (gas: 265622)
-[32m[PASS][0m testRevert_exercise_whenInvalidOption() (gas: 252122)
-[32m[PASS][0m testRevert_newOptionType_whenExerciseWindowTooShort() (gas: 23334)
-[32m[PASS][0m testRevert_newOptionType_whenExpiryWindowTooShort() (gas: 24821)
-[32m[PASS][0m testRevert_newOptionType_whenInvalidAssets() (gas: 21521)
-[32m[PASS][0m testRevert_newOptionType_whenOptionsTypeExists() (gas: 26485)
-[32m[PASS][0m testRevert_newOptionType_whenTotalSuppliesAreTooLowToExercise() (gas: 44326)
-[32m[PASS][0m testRevert_option_whenOptionDoesNotExist() (gas: 12449)
-[32m[PASS][0m testRevert_position_whenExpiredOption() (gas: 19216)
-[32m[PASS][0m testRevert_position_whenTokenNotFound() (gas: 11847)
-[32m[PASS][0m testRevert_redeem_whenCallerDoesNotOwnClaimId() (gas: 245351)
-[32m[PASS][0m testRevert_redeem_whenClaimTooSoon() (gas: 257881)
-[32m[PASS][0m testRevert_redeem_whenInvalidClaim() (gas: 9432)
-[32m[PASS][0m testRevert_setFeeTo_whenNotCurrentFeeTo() (gas: 11919)
-[32m[PASS][0m testRevert_setFeeTo_whenZeroAddress() (gas: 11619)
-[32m[PASS][0m testRevert_setFeesEnabled_whenNotFeeTo() (gas: 11843)
-[32m[PASS][0m testRevert_setTokenURIGenerator_whenNotCurrentFeeTo() (gas: 11889)
-[32m[PASS][0m testRevert_setTokenURIGenerator_whenZeroAddress() (gas: 11631)
-[32m[PASS][0m testRevert_sweepFees_whenNotFeeTo() (gas: 16949)
-[32m[PASS][0m testRevert_uri_whenTokenNotFound() (gas: 18686)
-[32m[PASS][0m testRevert_write_whenAmountWrittenCannotBeZero() (gas: 10763)
-[32m[PASS][0m testRevert_write_whenCallerDoesNotOwnClaimId() (gas: 259607)
-[32m[PASS][0m testRevert_write_whenCallerHasNotGrantedSufficientApprovalToEngine() (gas: 678929)
-[32m[PASS][0m testRevert_write_whenCallerHoldsInsufficientExerciseAsset() (gas: 679033)
-[32m[PASS][0m testRevert_write_whenExpiredOption() (gas: 16935)
-[32m[PASS][0m testRevert_write_whenInvalidOption() (gas: 13604)
-[32m[PASS][0m test_claim_whenWrittenMultiple() (gas: 378459)
-[32m[PASS][0m test_claim_whenWrittenMultipleTimesOnMultipleClaims() (gas: 453124)
-[32m[PASS][0m test_claim_whenWrittenOnce() (gas: 302178)
-[32m[PASS][0m test_exercise() (gas: 380988)
-[32m[PASS][0m test_exercise_whenExercisingMultipleTimes() (gas: 418925)
-[32m[PASS][0m test_feeBalance_whenFeeOff() (gas: 266569)
-[32m[PASS][0m test_feeBalance_whenFeeOn() (gas: 323166)
-[32m[PASS][0m test_feeBalance_whenMinimum() (gas: 398134)
-[32m[PASS][0m test_feeBps() (gas: 5622)
-[32m[PASS][0m test_feeTo() (gas: 7759)
-[32m[PASS][0m test_feesEnabled() (gas: 7640)
-[32m[PASS][0m test_newOptionType() (gas: 129995)
-[32m[PASS][0m test_option_returnsOptionInfo() (gas: 25650)
-[32m[PASS][0m test_position_whenFullyExercisedClaim() (gas: 302150)
-[32m[PASS][0m test_position_whenOption() (gas: 30855)
-[32m[PASS][0m test_position_whenPartiallyExercisedClaim() (gas: 424981)
-[32m[PASS][0m test_position_whenUnexercisedClaim() (gas: 261693)
-[32m[PASS][0m test_redeem_whenFullyExercised() (gas: 332651)
-[32m[PASS][0m test_redeem_whenPartiallyExercised() (gas: 343293)
-[32m[PASS][0m test_redeem_whenUnexercised() (gas: 233616)
-[32m[PASS][0m test_setFeeToAndAcceptFeeTo() (gas: 29492)
-[32m[PASS][0m test_setFeeToAndAcceptFeeTo_multipleTimes() (gas: 50393)
-[32m[PASS][0m test_setFeesEnabled() (gas: 20603)
-[32m[PASS][0m test_setTokenURIGenerator() (gas: 2036256)
-[32m[PASS][0m test_sweepFees() (gas: 369953)
-[32m[PASS][0m test_sweepFees_whenNoFees() (gas: 45547)
-[32m[PASS][0m test_tokenType_returnsClaim() (gas: 251315)
-[32m[PASS][0m test_tokenType_returnsNone() (gas: 8025)
-[32m[PASS][0m test_tokenType_returnsOption() (gas: 10216)
-[32m[PASS][0m test_tokenURIGenerator() (gas: 9963)
-[32m[PASS][0m test_uri() (gas: 479544)
-[32m[PASS][0m test_write_whenExistingClaim() (gas: 293868)
-[32m[PASS][0m test_write_whenFeeOff() (gas: 254362)
-[32m[PASS][0m test_write_whenNewClaim() (gas: 275707)
-Test result: [32mok[0m. 68 passed; 0 failed; finished in 8.08ms
-
-Running 3 tests for test/OptionSettlementEngine.invariant.t.sol:OptionSettlementEngineInvariantTest
-[32m[PASS][0m invariant_erc20_balances() (runs: 10, calls: 10000, reverts: 4524)
-[32m[PASS][0m invariant_options_written_match_claims() (runs: 10, calls: 10000, reverts: 4524)
-[32m[PASS][0m invariant_positions_accounting() (runs: 10, calls: 10000, reverts: 4524)
-Test result: [32mok[0m. 3 passed; 0 failed; finished in 2.71s
-
-Running 4 tests for test/OptionSettlementEngine.fuzz.t.sol:OptionSettlementFuzzTest
-[32m[PASS][0m test_fuzzExercise(uint112,uint112) (runs: 256, μ: 364680, ~: 365722)
-[32m[PASS][0m test_fuzzNewOptionType(uint96,uint96,uint40,uint40) (runs: 256, μ: 130922, ~: 130922)
-[32m[PASS][0m test_fuzzWrite(uint112) (runs: 256, μ: 281992, ~: 281992)
-[32m[PASS][0m test_fuzzWriteExerciseRedeem(uint32) (runs: 256, μ: 9409473, ~: 9515885)
-Test result: [32mok[0m. 4 passed; 0 failed; finished in 2.76s
 | src/OptionSettlementEngine.sol:OptionSettlementEngine contract |                 |        |        |        |         |
 |----------------------------------------------------------------|-----------------|--------|--------|--------|---------|
 | Deployment Cost                                                | Deployment Size |        |        |        |         |
-| 3262505                                                        | 16430           |        |        |        |         |
+| 9273036                                                        | 16911           |        |        |        |         |
 | Function Name                                                  | min             | avg    | median | max    | # calls |
 | acceptFeeTo                                                    | 585             | 2455   | 2705   | 3825   | 4       |
-| balanceOf                                                      | 619             | 619    | 619    | 619    | 170     |
+| balanceOf                                                      | 619             | 619    | 619    | 619    | 48      |
 | claim                                                          | 831             | 3008   | 3051   | 4660   | 34      |
-| exercise                                                       | 513             | 30410  | 19641  | 82341  | 84      |
+| exercise                                                       | 513             | 61959  | 64003  | 107657 | 42      |
 | feeBalance                                                     | 641             | 1391   | 641    | 2641   | 24      |
-| feeBps                                                         | 338             | 338    | 338    | 338    | 36      |
-| feeTo                                                          | 383             | 583    | 383    | 2383   | 20      |
+| feeBps                                                         | 338             | 338    | 338    | 338    | 33      |
+| feeTo                                                          | 383             | 668    | 383    | 2383   | 14      |
 | feesEnabled                                                    | 350             | 1016   | 350    | 2350   | 3       |
-| newOptionType                                                  | 3527            | 92758  | 97071  | 106071 | 105     |
-| option                                                         | 1978            | 3231   | 1978   | 9978   | 7       |
-| position                                                       | 1272            | 6294   | 4433   | 21722  | 35      |
-| redeem                                                         | 465             | 12252  | 12704  | 28800  | 39      |
-| safeTransferFrom                                               | 3522            | 16063  | 19442  | 28802  | 71      |
+| newOptionType                                                  | 3527            | 92012  | 96375  | 110175 | 95      |
+| option                                                         | 1714            | 3468   | 2222   | 7714   | 4       |
+| position                                                       | 1272            | 4933   | 4433   | 7875   | 11      |
+| redeem                                                         | 465             | 23598  | 31531  | 35556  | 18      |
+| safeTransferFrom                                               | 21042           | 24692  | 23042  | 28802  | 17      |
 | setFeeTo                                                       | 2614            | 16363  | 21712  | 24712  | 6       |
-| setFeesEnabled                                                 | 1690            | 2279   | 2112   | 6912   | 87      |
+| setFeesEnabled                                                 | 1690            | 2293   | 2112   | 6912   | 80      |
 | setTokenURIGenerator                                           | 2638            | 4715   | 2733   | 8775   | 3       |
 | sweepFees                                                      | 2885            | 37700  | 18258  | 83958  | 7       |
-| tokenType                                                      | 724             | 1647   | 1062   | 2724   | 5       |
+| tokenType                                                      | 1062            | 2150   | 2665   | 2724   | 3       |
 | tokenURIGenerator                                              | 426             | 1426   | 1426   | 2426   | 2       |
-| uri                                                            | 9574            | 236921 | 236921 | 464268 | 2       |
-| write                                                          | 450             | 145487 | 124476 | 239400 | 136     |
-
-
-| src/TokenURIGenerator.sol:TokenURIGenerator contract |                 |        |        |        |         |
-|------------------------------------------------------|-----------------|--------|--------|--------|---------|
-| Deployment Cost                                      | Deployment Size |        |        |        |         |
-| 1982498                                              | 9934            |        |        |        |         |
-| Function Name                                        | min             | avg    | median | max    | # calls |
-| constructTokenURI                                    | 420110          | 420110 | 420110 | 420110 | 1       |
-
-
-| test/utils/MockERC20.sol:MockERC20 contract |                 |       |        |       |         |
-|---------------------------------------------|-----------------|-------|--------|-------|---------|
-| Deployment Cost                             | Deployment Size |       |        |       |         |
-| 648998                                      | 4360            |       |        |       |         |
-| Function Name                               | min             | avg   | median | max   | # calls |
-| approve                                     | 2546            | 24528 | 24546  | 24546 | 2526    |
-| balanceOf                                   | 542             | 831   | 542    | 2542  | 166     |
-| decimals                                    | 249             | 249   | 249    | 249   | 2       |
-| mint                                        | 2896            | 31892 | 24796  | 46696 | 2526    |
-| symbol                                      | 3236            | 3236  | 3236   | 3236  | 2       |
-| totalSupply                                 | 363             | 637   | 363    | 2363  | 204     |
-| transfer                                    | 2985            | 5025  | 2985   | 24885 | 133     |
-| transferFrom                                | 824             | 11816 | 3381   | 32081 | 211     |
-
-
-
+| uri                                                            | 7447            | 235140 | 235140 | 462833 | 2       |
+| write                                                          | 450             | 183961 | 224805 | 265437 | 80      |

--- a/foundry.toml
+++ b/foundry.toml
@@ -3,6 +3,7 @@ src = 'src'
 out = 'out'
 libs = ['lib']
 remappings = ['forge-std/=lib/forge-std/src/', 'solmate/=lib/solmate/src/']
+gas_reports = ['OptionSettlementEngine']
 
 [fuzz]
 seed = 7

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
         "solhint:check": "solhint --config ./.solhint.json 'src/**/*.sol'",
         "lint": "npm run fmt && npm run solhint",
         "lint:check": "npm run fmt:check && npm run solhint:check",
-        "test": "forge test --optimize"
+        "test": "forge test --optimize",
+        "gas": "forge test --no-match-contract 'Fuzz|Invariant' --gas-report | sed '/|/!d' |tee .gas-snapshot"
     },
     "devDependencies": {
         "solhint": "^3.3.6"

--- a/src/OptionSettlementEngine.sol
+++ b/src/OptionSettlementEngine.sol
@@ -392,9 +392,13 @@ contract OptionSettlementEngine is ERC1155, IOptionSettlementEngine {
             exerciseAmount: exerciseAmount,
             exerciseTimestamp: exerciseTimestamp,
             expiryTimestamp: expiryTimestamp,
-            settlementSeed: optionKey, // TODO leaving for now, to not break tests while writing POC
             nextClaimKey: 1
         });
+
+        // Record entropy.
+        EntropyPoolLib.recordEntropy(
+            entropyPool, keccak256(abi.encode(msg.sender, blockhash(block.number - 1), optionKey))
+        );
 
         emit NewOptionType(
             optionId,
@@ -444,6 +448,11 @@ contract OptionSettlementEngine is ERC1155, IOptionSettlementEngine {
         if (feesEnabled) {
             fee = _calculateRecordAndEmitFee(encodedOptionId, underlyingAsset, rxAmount);
         }
+
+        // Record entropy.
+        EntropyPoolLib.recordEntropy(
+            entropyPool, keccak256(abi.encode(msg.sender, blockhash(block.number - 1), optionKey, amount))
+        );
 
         if (claimKey == 0) {
             // Then create a new claim.
@@ -552,6 +561,16 @@ contract OptionSettlementEngine is ERC1155, IOptionSettlementEngine {
             totalExerciseAssetAmount,
             totalUnderlyingAssetAmount
             );
+
+        // Record entropy.
+        EntropyPoolLib.recordEntropy(
+            entropyPool,
+            keccak256(
+                abi.encode(
+                    msg.sender, blockhash(block.number - 1), optionKey, underlyingAssetAmount, exerciseAssetAmount
+                )
+            )
+        );
 
         // Burn the claim NFT and make transfers.
         _burn(msg.sender, claimId, 1);

--- a/src/OptionSettlementEngine.sol
+++ b/src/OptionSettlementEngine.sol
@@ -835,7 +835,7 @@ contract OptionSettlementEngine is ERC1155, IOptionSettlementEngine {
         Bucket[] storage buckets = optionTypeState.bucketInfo.buckets;
         uint96[] storage unexercisedBucketIndices = optionTypeState.bucketInfo.unexercisedBucketIndices;
         uint96 numUnexercisedBuckets = uint96(unexercisedBucketIndices.length);
-        bytes32 entropicElement = EntropyPoolLib.getEntropy(entropyPool);
+        bytes32 entropicElement = EntropyPoolLib.useEntropy(entropyPool);
         uint96 exerciseIndex = uint96(uint256(entropicElement) % numUnexercisedBuckets);
 
         while (amount > 0) {

--- a/src/OptionSettlementEngine.sol
+++ b/src/OptionSettlementEngine.sol
@@ -113,7 +113,7 @@ contract OptionSettlementEngine is ERC1155, IOptionSettlementEngine {
     /// @notice The new feeTo address, pending explicit acceptance by this address.
     address private pendingFeeTo;
 
-    Queue private globalEntropyQueue;
+    QueueLib.Queue private entropyPool;
 
     /*//////////////////////////////////////////////////////////////
     //  State Variables - Public
@@ -161,7 +161,7 @@ contract OptionSettlementEngine is ERC1155, IOptionSettlementEngine {
         feeTo = _feeTo;
         tokenURIGenerator = ITokenURIGenerator(_tokenURIGenerator);
 
-        globalEntropyQueue = new Queue();
+        QueueLib.init(entropyPool);
     }
 
     /*//////////////////////////////////////////////////////////////
@@ -778,7 +778,7 @@ contract OptionSettlementEngine is ERC1155, IOptionSettlementEngine {
      * @return entropicElement The element providing entropy.
      */
     function _getEntropy() private returns (bytes32 entropicElement) {
-        entropicElement = globalEntropyQueue.dequeue();
+        entropicElement = QueueLib.dequeue(entropyPool);
     }
 
     /*//////////////////////////////////////////////////////////////
@@ -795,7 +795,7 @@ contract OptionSettlementEngine is ERC1155, IOptionSettlementEngine {
      * @param entropicElement The element providing entropy.
      */
     function _recordEntropy(bytes32 entropicElement) private {
-        globalEntropyQueue.enqueue(entropicElement);
+        QueueLib.enqueue(entropyPool, entropicElement);
     }
 
     //

--- a/src/interfaces/IOptionSettlementEngine.sol
+++ b/src/interfaces/IOptionSettlementEngine.sol
@@ -250,7 +250,7 @@ interface IOptionSettlementEngine {
         /// @custom:member expiryTimestamp The timestamp before which this option can be exercised.
         uint40 expiryTimestamp;
         /// @custom:member settlementSeed Deterministic seed used for option fair exercise assignment.
-        uint160 settlementSeed;
+        uint160 settlementSeed; // TODO leaving for now, to not break tests while writing POC
         /// @custom:member nextClaimKey The next claim key available for this option type.
         uint96 nextClaimKey;
     }

--- a/src/interfaces/IOptionSettlementEngine.sol
+++ b/src/interfaces/IOptionSettlementEngine.sol
@@ -249,8 +249,6 @@ interface IOptionSettlementEngine {
         uint40 exerciseTimestamp;
         /// @custom:member expiryTimestamp The timestamp before which this option can be exercised.
         uint40 expiryTimestamp;
-        /// @custom:member settlementSeed Deterministic seed used for option fair exercise assignment.
-        uint160 settlementSeed; // TODO leaving for now, to not break tests while writing POC
         /// @custom:member nextClaimKey The next claim key available for this option type.
         uint96 nextClaimKey;
     }

--- a/src/utils/EntropyPool.sol
+++ b/src/utils/EntropyPool.sol
@@ -12,6 +12,10 @@ library EntropyPoolLib {
         QueueLib.Queue _queue;
     }
 
+    function checkEntropy(EntropyPool storage entropyPool) internal view returns (uint256 queueSize) {
+        queueSize = QueueLib.size(entropyPool._queue);
+    }
+
     function seedEntropy(EntropyPool storage entropyPool) internal {
         QueueLib.init(entropyPool._queue);
         for (uint256 i = 1; i <= 256; i++) {
@@ -19,7 +23,7 @@ library EntropyPoolLib {
         }
     }
 
-    function getEntropy(EntropyPool storage entropyPool) internal returns (bytes32 entropicElement) {
+    function useEntropy(EntropyPool storage entropyPool) internal returns (bytes32 entropicElement) {
         entropicElement = QueueLib.dequeue(entropyPool._queue);
     }
 

--- a/src/utils/EntropyPool.sol
+++ b/src/utils/EntropyPool.sol
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: BUSL 1.1
+// Valorem Labs Inc. (c) 2022.
+pragma solidity 0.8.16;
+
+import "./Queue.sol";
+
+// TODO
+library EntropyPoolLib {
+    uint16 private constant MAX_ELEMENTS = 2_048;
+
+    struct EntropyPool {
+        QueueLib.Queue _queue;
+    }
+
+    function seedEntropy(EntropyPool storage entropyPool) internal {
+        QueueLib.init(entropyPool._queue);
+        for (uint256 i = 1; i <= 256; i++) {
+            EntropyPoolLib.recordEntropy(entropyPool, keccak256(abi.encode(msg.sender, blockhash(block.number - i))));
+        }
+    }
+
+    function getEntropy(EntropyPool storage entropyPool) internal returns (bytes32 entropicElement) {
+        entropicElement = QueueLib.dequeue(entropyPool._queue);
+    }
+
+    function recordEntropy(EntropyPool storage entropyPool, bytes32 entropicElement) internal {
+        if (QueueLib.size(entropyPool._queue) < MAX_ELEMENTS) {
+            QueueLib.enqueue(entropyPool._queue, entropicElement);
+        }
+    }
+}

--- a/src/utils/Queue.sol
+++ b/src/utils/Queue.sol
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: BUSL 1.1
+// Valorem Labs Inc. (c) 2022.
+pragma solidity 0.8.16;
+
+contract Queue {
+    error EmptyQueue();
+
+    mapping(uint256 => bytes32) private queue;
+    uint256 private first = 1;
+    uint256 private last = 0;
+
+    function size() public view returns (uint256) {
+        return last;
+    }
+
+    function enqueue(bytes32 element) public {
+        last++;
+        queue[last] = element;
+    }
+
+    function dequeue() public returns (bytes32 element) {
+        if (last < first) {
+            revert EmptyQueue();
+        }
+
+        element = queue[first];
+        delete queue[first];
+        first++;
+    }
+}

--- a/src/utils/Queue.sol
+++ b/src/utils/Queue.sol
@@ -2,29 +2,36 @@
 // Valorem Labs Inc. (c) 2022.
 pragma solidity 0.8.16;
 
-contract Queue {
+library QueueLib {
     error EmptyQueue();
 
-    mapping(uint256 => bytes32) private queue;
-    uint256 private first = 1;
-    uint256 private last = 0;
-
-    function size() public view returns (uint256) {
-        return last;
+    struct Queue {
+        mapping(uint256 => bytes32) _queue;
+        uint256 _first;
+        uint256 _last;
     }
 
-    function enqueue(bytes32 element) public {
-        last++;
-        queue[last] = element;
+    function init(Queue storage queue) internal {
+        queue._first = 1;
+        queue._last = 0;
     }
 
-    function dequeue() public returns (bytes32 element) {
-        if (last < first) {
+    function size(Queue storage queue) internal view returns (uint256) {
+        return queue._last;
+    }
+
+    function enqueue(Queue storage queue, bytes32 element) internal {
+        queue._last++;
+        queue._queue[queue._last] = element;
+    }
+
+    function dequeue(Queue storage queue) internal returns (bytes32 element) {
+        if (queue._last < queue._first) {
             revert EmptyQueue();
         }
 
-        element = queue[first];
-        delete queue[first];
-        first++;
+        element = queue._queue[queue._first];
+        delete queue._queue[queue._first];
+        queue._first++;
     }
 }

--- a/src/utils/Queue.sol
+++ b/src/utils/Queue.sol
@@ -2,6 +2,7 @@
 // Valorem Labs Inc. (c) 2022.
 pragma solidity 0.8.16;
 
+// TODO
 library QueueLib {
     error EmptyQueue();
 

--- a/test/OptionSettlementEngine.integration.t.sol
+++ b/test/OptionSettlementEngine.integration.t.sol
@@ -4,9 +4,7 @@ pragma solidity 0.8.16;
 
 import "./utils/BaseEngineTest.sol";
 
-// TODO Encountered 2 failing tests in test/OptionSettlementEngine.integration.t.sol:OptionSettlementIntegrationTest
-// [FAIL. Reason: Assertion failed.] test_integrationFairAssignment() (gas: 761942)
-// [FAIL. Reason: Assertion failed.] test_integrationWriteExerciseAddBuckets() (gas: 1345106)
+// TODO Parameterize the expected values in test_integrationFairAssignment
 
 /// @notice Integration tests for OptionSettlementEngine
 contract OptionSettlementIntegrationTest is BaseEngineTest {
@@ -27,14 +25,14 @@ contract OptionSettlementIntegrationTest is BaseEngineTest {
         IOptionSettlementEngine.Claim memory claim2 = engine.claim(claimId2);
         IOptionSettlementEngine.Claim memory claim3 = engine.claim(claimId3);
 
-        assertEq(claim1.amountWritten, WAD);
-        assertEq(claim1.amountExercised, FixedPointMathLib.divWadDown(1 * 1, 2));
+        assertEq(claim1.amountWritten, WAD, "claim 1 amount written -- before");
+        assertEq(claim1.amountExercised, FixedPointMathLib.divWadDown(1 * 1, 2), "claim 1 amount exercised -- before");
 
-        assertEq(claim2.amountWritten, WAD);
-        assertEq(claim2.amountExercised, FixedPointMathLib.divWadDown(1 * 1, 2));
+        assertEq(claim2.amountWritten, WAD, "claim 2 amount written -- before");
+        assertEq(claim2.amountExercised, FixedPointMathLib.divWadDown(1 * 1, 2), "claim 2 amount exercised -- before");
 
-        assertEq(claim3.amountWritten, 2 * WAD);
-        assertEq(claim3.amountExercised, 0);
+        assertEq(claim3.amountWritten, 2 * WAD, "claim 3 amount written -- before");
+        assertEq(claim3.amountExercised, 0, "claim 3 amount exercised -- before");
 
         engine.exercise(testOptionId, 1);
 
@@ -45,14 +43,26 @@ contract OptionSettlementIntegrationTest is BaseEngineTest {
         // 50/50 chance of exercising in first (claim 1 & 2) bucket or second bucket (claim 3)
         // 1 option is written in this claim, two options are exercised in the bucket, and in
         // total, 2 options are written
-        assertEq(claim1.amountWritten, WAD);
-        assertEq(claim1.amountExercised, FixedPointMathLib.divWadDown(1 * 2, 2));
+        assertEq(claim1.amountWritten, WAD, "claim 1 amount written -- after 2nd exercise");
+        assertEq(
+            claim1.amountExercised,
+            FixedPointMathLib.divWadDown(1 * 2, 4),
+            "claim 1 amount exercised -- after 2nd exercise"
+        );
 
-        assertEq(claim2.amountWritten, WAD);
-        assertEq(claim2.amountExercised, FixedPointMathLib.divWadDown(1 * 2, 2));
+        assertEq(claim2.amountWritten, WAD, "claim 2 amount written -- after 2nd exercise");
+        assertEq(
+            claim2.amountExercised,
+            FixedPointMathLib.divWadDown(1 * 2, 4),
+            "claim 2 amount exercised -- after 2nd exercise"
+        );
 
-        assertEq(claim3.amountWritten, 2 * WAD);
-        assertEq(claim3.amountExercised, 0);
+        assertEq(claim3.amountWritten, 2 * WAD, "claim 3 amount written -- after 2nd exercise");
+        assertEq(
+            claim3.amountExercised,
+            FixedPointMathLib.divWadDown(1 * 2, 2),
+            "claim 3 amount exercised -- after 2nd exercise"
+        );
 
         // First bucket is fully exercised, this will be performed on the second
         engine.exercise(testOptionId, 1);
@@ -61,14 +71,26 @@ contract OptionSettlementIntegrationTest is BaseEngineTest {
         claim2 = engine.claim(claimId2);
         claim3 = engine.claim(claimId3);
 
-        assertEq(claim1.amountWritten, WAD);
-        assertEq(claim1.amountExercised, FixedPointMathLib.divWadDown(1 * 2, 2));
+        assertEq(claim1.amountWritten, WAD, "claim 1 amount written -- after 3rd exercise");
+        assertEq(
+            claim1.amountExercised,
+            FixedPointMathLib.divWadDown(1 * 2, 4),
+            "claim 1 amount exercised -- after 3rd exercise"
+        );
 
-        assertEq(claim2.amountWritten, WAD);
-        assertEq(claim2.amountExercised, FixedPointMathLib.divWadDown(1 * 2, 2));
+        assertEq(claim2.amountWritten, WAD, "claim 2 amount written -- after 3rd exercise");
+        assertEq(
+            claim2.amountExercised,
+            FixedPointMathLib.divWadDown(1 * 2, 4),
+            "claim 2 amount exercised -- after 3rd exercise"
+        );
 
-        assertEq(claim3.amountWritten, 2 * WAD);
-        assertEq(claim3.amountExercised, FixedPointMathLib.divWadDown(2 * 1, 2));
+        assertEq(claim3.amountWritten, 2 * WAD, "claim 3 amount written -- after 3rd exercise");
+        assertEq(
+            claim3.amountExercised,
+            FixedPointMathLib.divWadDown(2 * 1, 1),
+            "claim 3 amount exercised -- after 3rd exercise"
+        );
 
         // Both buckets are fully exercised
         engine.exercise(testOptionId, 1);
@@ -77,14 +99,26 @@ contract OptionSettlementIntegrationTest is BaseEngineTest {
         claim2 = engine.claim(claimId2);
         claim3 = engine.claim(claimId3);
 
-        assertEq(claim1.amountWritten, WAD);
-        assertEq(claim1.amountExercised, FixedPointMathLib.divWadDown(1 * 2, 2));
+        assertEq(claim1.amountWritten, WAD, "claim 1 amount written -- after 4th exercise");
+        assertEq(
+            claim1.amountExercised,
+            FixedPointMathLib.divWadDown(1 * 2, 2),
+            "claim 1 amount exercised -- after 4th exercise"
+        );
 
-        assertEq(claim2.amountWritten, WAD);
-        assertEq(claim2.amountExercised, FixedPointMathLib.divWadDown(1 * 2, 2));
+        assertEq(claim2.amountWritten, WAD, "claim 2 amount written -- after 4th exercise");
+        assertEq(
+            claim2.amountExercised,
+            FixedPointMathLib.divWadDown(1 * 2, 2),
+            "claim 2 amount exercised -- after 4th exercise"
+        );
 
-        assertEq(claim3.amountWritten, 2 * WAD);
-        assertEq(claim3.amountExercised, FixedPointMathLib.divWadDown(2 * 2, 2));
+        assertEq(claim3.amountWritten, 2 * WAD, "claim 3 amount written -- after 4th exercise");
+        assertEq(
+            claim3.amountExercised,
+            FixedPointMathLib.divWadDown(2 * 2, 2),
+            "claim 3 amount exercised -- after 4th exercise"
+        );
     }
 
     function test_integrationDustHandling() public {
@@ -263,7 +297,7 @@ contract OptionSettlementIntegrationTest is BaseEngineTest {
             totalExercised += claimData.amountExercised;
         }
 
-        assertEq(totalExercised, bucketsCreated * 1e18 - 1);
+        assertEq(totalExercised, bucketsCreated * 1e18, "total exercised");
     }
 
     function test_integrationSweepFeesWhenFeesAccruedForWrite() public {

--- a/test/OptionSettlementEngine.integration.t.sol
+++ b/test/OptionSettlementEngine.integration.t.sol
@@ -4,6 +4,10 @@ pragma solidity 0.8.16;
 
 import "./utils/BaseEngineTest.sol";
 
+// TODO Encountered 2 failing tests in test/OptionSettlementEngine.integration.t.sol:OptionSettlementIntegrationTest
+// [FAIL. Reason: Assertion failed.] test_integrationFairAssignment() (gas: 761942)
+// [FAIL. Reason: Assertion failed.] test_integrationWriteExerciseAddBuckets() (gas: 1345106)
+
 /// @notice Integration tests for OptionSettlementEngine
 contract OptionSettlementIntegrationTest is BaseEngineTest {
     function test_integrationFairAssignment() public {

--- a/test/OptionSettlementEngine.unit.t.sol
+++ b/test/OptionSettlementEngine.unit.t.sol
@@ -391,7 +391,6 @@ contract OptionSettlementUnitTest is BaseEngineTest {
             exerciseAmount: testExerciseAmount,
             exerciseTimestamp: testExerciseTimestamp,
             expiryTimestamp: testExpiryTimestamp,
-            settlementSeed: 0,
             nextClaimKey: 0
         });
 
@@ -441,7 +440,6 @@ contract OptionSettlementUnitTest is BaseEngineTest {
             exerciseAmount: testExerciseAmount,
             exerciseTimestamp: uint40(block.timestamp),
             expiryTimestamp: tooSoonExpiryTimestamp,
-            settlementSeed: 0, // default zero for settlement seed
             nextClaimKey: 0 // default zero for next claim id
         });
         _createOptionIdFromStruct(option);

--- a/test/QueueTest.t.sol
+++ b/test/QueueTest.t.sol
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: BUSL 1.1
+// Valorem Labs Inc. (c) 2022.
+pragma solidity 0.8.16;
+
+import "forge-std/Test.sol";
+
+import "../src/utils/Queue.sol";
+
+contract QueueTest is Test {
+    Queue private queue;
+
+    bytes32[] private elements;
+
+    function setUp() public {
+        queue = new Queue();
+
+        elements = new bytes32[](15);
+        elements[0] = keccak256(bytes("too many secrets"));
+        elements[1] = keccak256(bytes("setec astronomy"));
+        elements[2] = keccak256(bytes("cray tomes on set"));
+        elements[3] = keccak256(bytes("o no my tesseract"));
+        elements[4] = keccak256(bytes("ye some contrast"));
+        elements[5] = keccak256(bytes("a tron ecosystem"));
+        elements[6] = keccak256(bytes("stonecasty rome"));
+        elements[7] = keccak256(bytes("coy teamster son"));
+        elements[8] = keccak256(bytes("cyanometer toss"));
+        elements[9] = keccak256(bytes("cementatory sos"));
+        elements[10] = keccak256(bytes("my cotoneasters"));
+        elements[11] = keccak256(bytes("ny sec stateroom"));
+        elements[12] = keccak256(bytes("oc attorney mess"));
+        elements[13] = keccak256(bytes("my cots earstones"));
+        elements[14] = keccak256(bytes("easternmost coy"));
+    }
+
+    function test_size() public {
+        assertEq(queue.size(), 0, "initial size");
+
+        queue.enqueue(keccak256(bytes("42")));
+        assertEq(queue.size(), 1, "size after 1");
+
+        for (uint256 i = 0; i < elements.length; i++) {
+            queue.enqueue(elements[i]);
+        }
+
+        assertEq(queue.size(), elements.length + 1, "size after enqueueing many");
+    }
+
+    function test_enqueue_dequeue() public {
+        queue.enqueue(keccak256(bytes("42")));
+
+        assertEq(queue.dequeue(), keccak256(bytes("42")), "dequeue after 1");
+
+        for (uint256 i = 0; i < elements.length; i++) {
+            queue.enqueue(elements[i]);
+        }
+
+        for (uint256 i = 0; i < elements.length; i++) {
+            bytes32 element = elements[i];
+            assertEq(queue.dequeue(), element, "dequeue after enqueueing many");
+        }
+    }
+
+    function testRevert_dequeue_whenEmptyQueue() public {
+        vm.expectRevert(Queue.EmptyQueue.selector);
+
+        queue.dequeue();
+    }
+}

--- a/test/QueueTest.t.sol
+++ b/test/QueueTest.t.sol
@@ -7,12 +7,12 @@ import "forge-std/Test.sol";
 import "../src/utils/Queue.sol";
 
 contract QueueTest is Test {
-    Queue private queue;
+    QueueLib.Queue private queue;
 
     bytes32[] private elements;
 
     function setUp() public {
-        queue = new Queue();
+        QueueLib.init(queue);
 
         elements = new bytes32[](15);
         elements[0] = keccak256(bytes("too many secrets"));
@@ -33,36 +33,35 @@ contract QueueTest is Test {
     }
 
     function test_size() public {
-        assertEq(queue.size(), 0, "initial size");
+        assertEq(QueueLib.size(queue), 0, "initial size");
 
-        queue.enqueue(keccak256(bytes("42")));
-        assertEq(queue.size(), 1, "size after 1");
+        QueueLib.enqueue(queue, keccak256(bytes("42")));
+        assertEq(QueueLib.size(queue), 1, "size after 1");
 
         for (uint256 i = 0; i < elements.length; i++) {
-            queue.enqueue(elements[i]);
+            QueueLib.enqueue(queue, elements[i]);
         }
 
-        assertEq(queue.size(), elements.length + 1, "size after enqueueing many");
+        assertEq(QueueLib.size(queue), elements.length + 1, "size after enqueueing many");
     }
 
     function test_enqueue_dequeue() public {
-        queue.enqueue(keccak256(bytes("42")));
+        QueueLib.enqueue(queue, keccak256(bytes("42")));
 
-        assertEq(queue.dequeue(), keccak256(bytes("42")), "dequeue after 1");
+        assertEq(QueueLib.dequeue(queue), keccak256(bytes("42")), "dequeue after 1");
 
         for (uint256 i = 0; i < elements.length; i++) {
-            queue.enqueue(elements[i]);
+            QueueLib.enqueue(queue, elements[i]);
         }
 
         for (uint256 i = 0; i < elements.length; i++) {
-            bytes32 element = elements[i];
-            assertEq(queue.dequeue(), element, "dequeue after enqueueing many");
+            assertEq(QueueLib.dequeue(queue), elements[i], "dequeue after enqueueing many");
         }
     }
 
     function testRevert_dequeue_whenEmptyQueue() public {
-        vm.expectRevert(Queue.EmptyQueue.selector);
+        vm.expectRevert(QueueLib.EmptyQueue.selector);
 
-        queue.dequeue();
+        QueueLib.dequeue(queue);
     }
 }

--- a/test/utils/BaseEngineTest.sol
+++ b/test/utils/BaseEngineTest.sol
@@ -233,7 +233,6 @@ abstract contract BaseEngineTest is Test {
             exerciseAmount: exerciseAmount,
             exerciseTimestamp: exerciseTimestamp,
             expiryTimestamp: expiryTimestamp,
-            settlementSeed: 0, // default zero for settlement seed
             nextClaimKey: 0 // default zero for next claim id
         });
         optionId = _createOptionIdFromStruct(option);
@@ -358,7 +357,6 @@ abstract contract BaseEngineTest is Test {
         assertEq(actual.exerciseAmount, expected.exerciseAmount);
         assertEq(actual.exerciseTimestamp, expected.exerciseTimestamp);
         assertEq(actual.expiryTimestamp, expected.expiryTimestamp);
-        assertEq(actual.settlementSeed, expected.settlementSeed);
         assertEq(actual.nextClaimKey, expected.nextClaimKey);
     }
 

--- a/test/utils/BaseEngineTest.sol
+++ b/test/utils/BaseEngineTest.sol
@@ -41,9 +41,12 @@ abstract contract BaseEngineTest is Test {
 
     IERC20[] public ERC20S;
 
-    uint256 internal constant STARTING_BALANCE = 1_000_000_000 * 1e18;
-    uint256 internal constant STARTING_BALANCE_USDC = 1_000_000_000 * 1e6;
-    uint256 internal constant STARTING_BALANCE_WETH = 1_000_000 * 1e18;
+    uint256 internal constant STARTING_BALANCE = 1_000_000_000e18;
+    uint256 internal constant STARTING_BALANCE_USDC = 1_000_000_000e6;
+    uint256 internal constant STARTING_BALANCE_WETH = 1_000_000e18;
+
+    uint256 internal constant TIME0 = 2_000_000_000;
+    uint256 internal constant BLOCK0 = 20_000_000;
 
     // Test option
     uint256 internal testOptionId;
@@ -57,6 +60,10 @@ abstract contract BaseEngineTest is Test {
     IOptionSettlementEngine.Option internal testOption;
 
     function setUp() public virtual {
+        // Warp/roll to deterministic time/block.
+        vm.warp(TIME0);
+        vm.roll(BLOCK0);
+
         // Deploy OptionSettlementEngine
         generator = new TokenURIGenerator();
         engine = new OptionSettlementEngine(FEE_TO, address(generator));


### PR DESCRIPTION
- Adds basic FIFO queue implementation
- Records entropy during newOptionType(), write(), exercise(), and redeem(), based on various present inputs
- Replaces settlementSeed with a dequeued entropic element from the global entropy queue in the modulo operation to select a bucket index
- Seeds entropy at construction time with the previous 256 block's hashes
- Queue is limited to 2,048 elements, at which point new entropic elements aren't added until the queue size decreases
- MAYBE can change width of entropic elements, to reduce type conversions in _assignExercise()